### PR TITLE
Add api_private_key to workload expansion providers

### DIFF
--- a/templates/elz-workload/providers.standalone
+++ b/templates/elz-workload/providers.standalone
@@ -49,3 +49,8 @@ variable "api_private_key_path" {
   description = "The local path to the API private key"
   default     = ""
 }
+variable "api_private_key" {
+  type        = string
+  description = "The API private key"
+  default     = ""
+}

--- a/templates/elz-workload/providers.standalone
+++ b/templates/elz-workload/providers.standalone
@@ -18,6 +18,7 @@ provider "oci" {
   tenancy_ocid     = var.tenancy_ocid
   user_ocid        = var.current_user_ocid
   fingerprint      = var.api_fingerprint
+  private_key      = var.api_private_key # if both set this takes precedence
   private_key_path = var.api_private_key_path
   region           = var.region
 }
@@ -26,6 +27,7 @@ provider "oci" {
   tenancy_ocid     = var.tenancy_ocid
   user_ocid        = var.current_user_ocid
   fingerprint      = var.api_fingerprint
+  private_key      = var.api_private_key # if both set this takes precedence
   private_key_path = var.api_private_key_path
   region           = local.home_region[0]
 }


### PR DESCRIPTION
( re-adding commit that got left out of earlier PR accidentally. )

We pass in only api_private_key in the new ci/cd (as GH Actions doesn't do file variables), so WE providers.tf needs to look there for key.