### PR TITLE
#49 fixing

### DIFF
--- a/modules/identity-domain-group/main.tf
+++ b/modules/identity-domain-group/main.tf
@@ -14,7 +14,7 @@ resource "null_resource" "groups" {
 
   provisioner "local-exec" {
     working_dir = path.module
-    command     = "python3 scripts/manage_identity_domain.py -d ${var.identity_domain_id} -g ${join(" ", var.group_names)}"
+    command     = "python3 scripts/manage_identity_domain.py -u ${var.current_user_ocid} -r ${var.region} -t ${var.tenancy_ocid} -a ${var.api_fingerprint} -p ${var.api_private_key_path} -d ${var.identity_domain_id} -g ${join(" ", var.group_names)}"
     on_failure  = continue
   }
 }

--- a/modules/identity-domain-group/variables.tf
+++ b/modules/identity-domain-group/variables.tf
@@ -7,3 +7,31 @@ variable "identity_domain_id" {
   type        = string
   description = "the OCID of identity domain"
 }
+
+variable "tenancy_ocid" {
+  type        = string
+  description = "The OCID of tenancy"
+}
+
+variable "region" {
+  type        = string
+  description = "The OCI region"
+}
+
+variable "current_user_ocid" {
+  type        = string
+  description = "The OCID of the current user"
+  default     = ""
+}
+
+variable "api_fingerprint" {
+  type        = string
+  description = "The fingerprint of API"
+  default     = ""
+}
+
+variable "api_private_key_path" {
+  type        = string
+  description = "The local path to the API private key"
+  default     = ""
+}

--- a/templates/elz-environment/main.tf
+++ b/templates/elz-environment/main.tf
@@ -17,10 +17,14 @@ module "compartment" {
 
 module "identity" {
   source             = "../elz-identity"
+
   tenancy_ocid       = var.tenancy_ocid
   region             = var.region
-  environment_prefix = var.environment_prefix
+  current_user_ocid  = var.current_user_ocid
+  api_fingerprint    = var.api_fingerprint
+  api_private_key_path = var.api_private_key_path
 
+  environment_prefix = var.environment_prefix
   environment_compartment_id   = module.compartment.compartments.environment.id
   environment_compartment_name = module.compartment.compartments.environment.name
   shared_compartment_id        = module.compartment.compartments.shared.id

--- a/templates/elz-environment/variables.tf
+++ b/templates/elz-environment/variables.tf
@@ -11,6 +11,24 @@ variable "region" {
   description = "The OCI region"
 }
 
+variable "current_user_ocid" {
+  type        = string
+  description = "The OCID of the current user"
+  default     = ""
+}
+
+variable "api_fingerprint" {
+  type        = string
+  description = "The fingerprint of API"
+  default     = ""
+}
+
+variable "api_private_key_path" {
+  type        = string
+  description = "The local path to the API private key"
+  default     = ""
+}
+
 variable "environment_prefix" {
   type        = string
   description = "the 1 character string representing the environment eg. P (prod), N (non-prod), D, T, U"

--- a/templates/elz-identity/iam.tf
+++ b/templates/elz-identity/iam.tf
@@ -179,7 +179,14 @@ module "groups" {
   source             = "../../modules/identity-domain-group"
   group_names        = local.identity_domain.group_names
   identity_domain_id = module.identity_domain.domain.id
+  tenancy_ocid       = var.tenancy_ocid
+  region             = var.region
+  current_user_ocid  = var.current_user_ocid
+  api_fingerprint    = var.api_fingerprint
+  api_private_key_path = var.api_private_key_path
+  
 }
+
 
 module "network_admin_policy" {
   source           = "../../modules/policies"

--- a/templates/elz-identity/variables.tf
+++ b/templates/elz-identity/variables.tf
@@ -11,6 +11,24 @@ variable "region" {
   description = "The OCI region"
 }
 
+variable "current_user_ocid" {
+  type        = string
+  description = "The OCID of the current user"
+  default     = ""
+}
+
+variable "api_fingerprint" {
+  type        = string
+  description = "The fingerprint of API"
+  default     = ""
+}
+
+variable "api_private_key_path" {
+  type        = string
+  description = "The local path to the API private key"
+  default     = ""
+}
+
 variable "environment_prefix" {
   type        = string
   description = "the 1 character string representing the environment eg. P (prod), N (non-prod), D, T, U"

--- a/templates/elz-workload/iam.tf
+++ b/templates/elz-workload/iam.tf
@@ -74,6 +74,11 @@ module "groups" {
   source             = "../../modules/identity-domain-group"
   identity_domain_id = var.identity_domain_id
   group_names        = values(local.group_names)
+  tenancy_ocid       = var.tenancy_ocid
+  region             = var.region
+  current_user_ocid  = var.current_user_ocid
+  api_fingerprint    = var.api_fingerprint
+  api_private_key_path = var.api_private_key_path  
 }
 
 module "workload_expansion_policy" {

--- a/templates/elz-workload/variables.tf
+++ b/templates/elz-workload/variables.tf
@@ -11,10 +11,30 @@ variable "region" {
   description = "The OCI region"
 }
 
+variable "current_user_ocid" {
+  type        = string
+  description = "The OCID of the current user"
+  default     = ""
+}
+
+variable "api_fingerprint" {
+  type        = string
+  description = "The fingerprint of API"
+  default     = ""
+}
+
+variable "api_private_key_path" {
+  type        = string
+  description = "The local path to the API private key"
+  default     = ""
+}
+
 variable "environment_prefix" {
   type        = string
   description = "the 1 character string representing the environment eg. P (prod), N (non-prod), D, T, U"
 }
+
+
 
 # -----------------------------------------------------------------------------
 # Compartment Variables

--- a/templates/enterprise-landing-zone/environment.tf
+++ b/templates/enterprise-landing-zone/environment.tf
@@ -14,6 +14,10 @@ module "prod_environment" {
 
   tenancy_ocid   = var.tenancy_ocid
   region         = var.region
+  current_user_ocid  = var.current_user_ocid
+  api_fingerprint    = var.api_fingerprint
+  api_private_key_path = var.api_private_key_path
+
   resource_label = var.resource_label
 
   home_compartment_id               = module.home_compartment.compartment_id
@@ -151,6 +155,9 @@ module "nonprod_environment" {
 
   tenancy_ocid   = var.tenancy_ocid
   region         = var.region
+  current_user_ocid  = var.current_user_ocid
+  api_fingerprint    = var.api_fingerprint
+  api_private_key_path = var.api_private_key_path  
   resource_label = var.resource_label
 
   home_compartment_id               = module.home_compartment.compartment_id

--- a/templates/freetrial-landing-zone/environment.tf
+++ b/templates/freetrial-landing-zone/environment.tf
@@ -14,6 +14,9 @@ module "prod_environment" {
 
   tenancy_ocid   = var.tenancy_ocid
   region         = var.region
+  current_user_ocid  = var.current_user_ocid
+  api_fingerprint    = var.api_fingerprint
+  api_private_key_path = var.api_private_key_path  
   resource_label = var.resource_label
 
   home_compartment_id                 = module.home_compartment.compartment_id


### PR DESCRIPTION
# Pull request for issue #49
https://github.com/oracle-quickstart/oci-landing-zones/issues/49

## Steps to reproduce the issue
Prior of pull request
- Clone repository in local PC (tested in MacOS, but has to be independent)
- Local PC has to have no DEFAULT configuration, or either, the DEFAULT configuration is not matching tfvars (related to other tenant)
- Create tfvars for specific tenant. For this, take the the example.tfvars in templates/enterprise-landing-zone
- If first time you deploy the landing zone, use terraform init. If you one to test in previously already deployed landing zone, copy `terraform.tfstate' file to oci-landing-zones/templates/enterprise-landing-zone
- Test deployment or re-deployment of only domain grous
```
cd oci-landing-zones/templates/enterprise-landing-zone
# terraform init only for new pure deployment
# terraform init
# else
# copy original terraform.tfstate to oci-landing-zones/templates/enterprise-landing-zone
terraform plan -replace="module.prod_environment.module.identity.module.groups.null_resource.groups[0]" --var-file ../../../myvars/demolandingzonev2.tfvars
terraform apply -replace="module.prod_environment.module.identity.module.groups.null_resource.groups[0]" --var-file ../../../myvars/demolandingzonev2.tfvars -auto-approve -no-color> demolandingzonev2.log
```

With the current bug, you will get this error in log file (twice, one for prod and other for nonprod)

```
module.prod_environment.module.identity.module.groups.null_resource.groups[0]: Provisioning with 'local-exec'...
module.prod_environment.module.identity.module.groups.null_resource.groups[0] (local-exec): Executing: ["/bin/sh" "-c" "python3 scripts/manage_identity_domain.py -d ocid1.domain.oc1..aaaaaaaaxyphapmclguhhjcluaymlzmg7q5rnd6bkw7z5wt5qx6s3vwgbc5q -g OCI-ELZ-UGP-P-IDP-ADMIN OCI-ELZ-UGP-P-NET-ADMIN OCI-ELZ-UGP-P-OPS-ADMIN OCI-ELZ-UGP-P-PLT-ADMIN OCI-ELZ-UGP-P-SEC-ADMIN"]
module.prod_environment.module.identity.module.groups.null_resource.groups[0]: Still creating... [10s elapsed]
module.prod_environment.module.identity.module.groups.null_resource.groups[0] (local-exec): Traceback (most recent call last):
module.prod_environment.module.identity.module.groups.null_resource.groups[0] (local-exec):   File "/Users/jmalbarran/Documents/OracleContent/Projects/OELZv2/oci-landing-zones/modules/identity-domain-group/scripts/manage_identity_domain.py", line 127, in <module>
module.prod_environment.module.identity.module.groups.null_resource.groups[0] (local-exec):     manage_id = ManageIdentityDomain(args.domain_id, args.group_names)
module.prod_environment.module.identity.module.groups.null_resource.groups[0] (local-exec):                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
module.prod_environment.module.identity.module.groups.null_resource.groups[0] (local-exec):   File "/Users/jmalbarran/Documents/OracleContent/Projects/OELZv2/oci-landing-zones/modules/identity-domain-group/scripts/manage_identity_domain.py", line 14, in __init__
module.prod_environment.module.identity.module.groups.null_resource.groups[0] (local-exec):     self.config, self.auth = self.set_up_oci_config()
module.prod_environment.module.identity.module.groups.null_resource.groups[0] (local-exec):                              ^^^^^^^^^^^^^^^^^^^^^^^^
module.prod_environment.module.identity.module.groups.null_resource.groups[0] (local-exec):   File "/Users/jmalbarran/Documents/OracleContent/Projects/OELZv2/oci-landing-zones/modules/identity-domain-group/scripts/manage_identity_domain.py", line 28, in set_up_oci_config
module.prod_environment.module.identity.module.groups.null_resource.groups[0] (local-exec):     tenancy=config['tenancy'],
module.prod_environment.module.identity.module.groups.null_resource.groups[0] (local-exec):             ~~~~~~^^^^^^^^^^^
module.prod_environment.module.identity.module.groups.null_resource.groups[0] (local-exec): KeyError: 'tenancy'
```

## Solving the issue
- Modify the calling module `oci-landing-zones/modules/identity-domain-group/main.tf` to call python module with all relevant variables
- Add the config variables to `oci-landing-zones/modules/identity-domain-group/variables.tf`
- Modify the module `oci-landing-zones/modules/identity-domain-groupscripts/manage_identity_domain.py``
    - Parse the new parameters
    - Create the config variable using the variables
- Modify template `oci_landing_zones/templates/elz-identity/iam.tf` and `oci_landing_zones/templates/elz-identity/variables.tf` to add the variables in the call to module
- Modify template `oci_landing_zones/templates/elz-workload/iam.tf` and `oci_landing_zones/templates/elz-workload/variables.tf` to add the variables in the call to module
- Modify template `oci_landing_zones/templates/elz-environment/main.tf` and `oci_landing_zones/templates/elz-environment/variables.tf` to add the variables in the call to module
- Modify template `oci_landing_zones/templates/elz-enterprise-landing-zone/environment.tf` and `oci_landing_zones/templates/freetrial-landing-zone/environment.tf` to add the variables in the call to module

## Test result after the change
module.nonprod_environment.module.identity.module.groups.null_resource.groups[0]: Provisioning with 'local-exec'...
module.nonprod_environment.module.identity.module.groups.null_resource.groups[0] (local-exec): Executing: ["/bin/sh" "-c" "python3 scripts/manage_identity_domain.py -u ocid1.user.oc1..aaaaaaaa32t7pzgze4tdqpzz2v3dis473wyv47iqdvtreazstykac33cfuiq -r eu-madrid-1 -t ocid1.tenancy.oc1..aaaaaaaawou44pxjus3zddeqpvrygtplbei2qj7vmzgzhsz6sh6livff5hoq -a 50:fb:5c:00:58:34:fc:d7:16:bb:eb:8f:72:90:80:66 -p ~/.ssh/oci_demolandingzonev2_private.pem -d ocid1.domain.oc1..aaaaaaaaxmi225tycc5tt4ijnyfmbsxtv6q7pcn4a4yosjmbejof4yqhn2oa -g OCI-ELZ-UGP-N-IDP-ADMIN OCI-ELZ-UGP-N-NET-ADMIN OCI-ELZ-UGP-N-OPS-ADMIN OCI-ELZ-UGP-N-PLT-ADMIN OCI-ELZ-UGP-N-SEC-ADMIN"]
module.nonprod_environment.module.identity.module.groups.null_resource.groups[0] (local-exec): Waiting for domain to enter ACTIVE state
module.nonprod_environment.module.identity.module.groups.null_resource.groups[0] (local-exec): Got domain url https://idcs-12d1cbac09d343b0b1d8ca5803a96073.identity.oraclecloud.com:443

**NOTICE** After these lines, we see error because the groups are duplicated because of previous test 

# PENDING Tests
- Freetrial landing zone from PC. The code is there but I cannot test now!
- Enterprise and Freetrial in ORM

# TODO
- Implement detroy provisioner for groups


