### PR TITLE
Workload Group Remove Python Dependency

### DIFF
--- a/templates/elz-workload/iam.tf
+++ b/templates/elz-workload/iam.tf
@@ -70,11 +70,30 @@ module "workload_compartment" {
   }
 }
 
-module "groups" {
-  source             = "../../modules/identity-domain-group"
-  identity_domain_id = var.identity_domain_id
-  group_names        = values(local.group_names)
+#module "groups" {
+#  source             = "../../modules/identity-domain-group"
+#  identity_domain_id = var.identity_domain_id
+#  group_names        = values(local.group_names)
+#}
+
+module "workload_admin_group" {
+  source                   = "../../modules/non-default-domain-group"
+  idcs_endpoint            = var.idcs_endpoint
+  group_display_name       = local.group_names.workload_admin_group_name
 }
+
+module "app_admin_group" {
+  source                   = "../../modules/non-default-domain-group"
+  idcs_endpoint            = var.idcs_endpoint
+  group_display_name       = local.group_names.application_admin_group_name
+}
+
+module "db_admin_group" {
+  source                   = "../../modules/non-default-domain-group"
+  idcs_endpoint            = var.idcs_endpoint
+  group_display_name       = local.group_names.database_admin_group_name
+}
+
 
 module "workload_expansion_policy" {
   source           = "../../modules/policies"

--- a/templates/elz-workload/variables.tf
+++ b/templates/elz-workload/variables.tf
@@ -168,6 +168,20 @@ variable "identity_domain_id" {
   }
 }
 
+variable "idcs_endpoint" {
+  type        = string
+  description = "Identity Domain End Points"
+  default     = "https://idcs-."
+  validation {
+    condition     = can(regex("^443$", split(":", var.idcs_endpoint)[2]))
+    error_message = "Not Valid IDCS Endpoint."
+  }
+  validation {
+    condition     =  can(regex("^https://idcs$", split("-", var.idcs_endpoint)[0]))
+    error_message = "Not Valid IDCS Endpoint."
+  }
+}
+
 variable "identity_domain_name" {
   type        = string
   description = "identity domain name"

--- a/templates/elz-workload/workload_extension.tfvars
+++ b/templates/elz-workload/workload_extension.tfvars
@@ -1,4 +1,5 @@
 # Provider 
+
 current_user_ocid    = ""
 region               = ""
 tenancy_ocid         = ""
@@ -25,6 +26,7 @@ security_compartment_id      = ""
 workload_admin_group_name    = ""
 application_admin_group_name = ""
 database_admin_group_name    = ""
+idcs_endpoint                = ""
 
 
 #####################################################
@@ -51,7 +53,7 @@ workload_private_spoke_subnet_app_display_name = ""
 workload_private_spoke_subnet_db_display_name = ""
 route_table_display_name = ""
 security_list_display_name = ""
-drg_id = ""
+
 
 #####################################################
 # Workload Expansion Monitoring Variables


### PR DESCRIPTION
Workload Group Remove Python Dependency .

New Variable is added to get the Identity IDCS endpoint URL and must be defined by end users on the “workload_extensions.tfvars”, and we are validating the input syntax for proper IDCS URL.
 
Input variable name:: idcs_endpoint
 
Proper Syntax for IDCS :: ^https://idcs-.*.identity.oraclecloud.com:443$ 