### PR TITLE
Added resource label to description names

### DIFF
--- a/templates/elz-identity/iam.tf
+++ b/templates/elz-identity/iam.tf
@@ -3,7 +3,7 @@
 # -----------------------------------------------------------------------------
 locals {
   identity_domain = {
-    domain_display_name       = "OCI-ELZ-${var.environment_prefix}-IDT"
+    domain_display_name       = "${var.resource_label}-OCI-ELZ-${var.environment_prefix}-IDT"
     domain_description        = "OCI Landing Zone ${var.environment_prefix} Identity Domain"
     domain_license_type       = var.domain_license_type
     domain_admin_user_name    = "domainadmin"
@@ -41,7 +41,7 @@ locals {
   }
 
   iam_admin_root_policy = {
-    name        = "OCI-ELZ-UGP-${var.environment_prefix}-IDP-ADMIN-ROOT-POLICY"
+    name        = "${var.resource_label}-OCI-ELZ-UGP-${var.environment_prefix}-IDP-ADMIN-ROOT-POLICY"
     description = "OCI Landing Zone IAM Group"
 
     statements = [
@@ -74,7 +74,7 @@ locals {
   }
 
   platform_admin_root_policy = {
-    name        = "OCI-ELZ-UGP-${var.environment_prefix}-PLT-ADMIN-ROOT-POLICY"
+    name        = "${var.resource_label}-OCI-ELZ-UGP-${var.environment_prefix}-PLT-ADMIN-ROOT-POLICY"
     description = "OCI Landing Zone Platform Admin Root Group"
 
     statements = [
@@ -142,7 +142,7 @@ locals {
   }
 
   security_admin_root_policy = {
-    name        = "OCI-ELZ-UGP-${var.environment_prefix}-SEC-ADMIN-ROOT-POLICY"
+    name        = "${var.resource_label}-OCI-ELZ-UGP-${var.environment_prefix}-SEC-ADMIN-ROOT-POLICY"
     description = "OCI Landing Zone Security Admin Group Root Compartment"
 
     statements = [

--- a/templates/elz-identity/variables.tf
+++ b/templates/elz-identity/variables.tf
@@ -24,6 +24,12 @@ variable "is_baseline_deploy" {
   type        = bool
   description = "TagNameSpace Optimization: Enable this flag to disable dependent module TagNameSpace Tag Creation."
 }
+
+variable "resource_label" {
+  type        = string
+  description = "Prefix used to avoid naming conflict"
+}
+
 # -----------------------------------------------------------------------------
 # Domain Variables
 # -----------------------------------------------------------------------------

--- a/templates/elz-tagging/main.tf
+++ b/templates/elz-tagging/main.tf
@@ -1,7 +1,7 @@
 locals {
   elz_tagging = {
     tag_namespace_description = "Tenancy Level Tag"
-    tag_namespace_name        = "ELZ-${var.environment_prefix}-Namespace"
+    tag_namespace_name        = "${var.resource_label}-ELZ-${var.environment_prefix}-Namespace"
     is_namespace_retired      = false
     tag_map = {
       cost_center = {

--- a/templates/elz-tagging/variables.tf
+++ b/templates/elz-tagging/variables.tf
@@ -43,3 +43,8 @@ variable "is_baseline_deploy" {
   type        = bool
   description = "TagNameSpace Optimization: Enable this flag to disable dependent module TagNameSpace Tag Creation."
 }
+
+variable "resource_label" {
+  type        = string
+  description = "Prefix used to avoid naming conflict"
+}

--- a/templates/enterprise-landing-zone/iam.tf
+++ b/templates/enterprise-landing-zone/iam.tf
@@ -4,14 +4,16 @@
 locals {
   home_compartment = {
     description = "Enterprise Landing Zone Home Compartment"
+    name = "${var.resource_label}-${var.home_compartment_name}"
   }
+
 }
 
 module "home_compartment" {
   source = "../../modules/compartment"
 
   compartment_parent_id     = var.tenancy_ocid
-  compartment_name          = var.home_compartment_name
+  compartment_name          = local.home_compartment.name
   compartment_description   = local.home_compartment.description
   enable_compartment_delete = var.enable_compartment_delete
 

--- a/templates/enterprise-landing-zone/logging.tf
+++ b/templates/enterprise-landing-zone/logging.tf
@@ -15,8 +15,8 @@ locals {
   }
 
   identity_domain = {
-    domain_display_prod_name     = "OCI-ELZ-${local.prod_environment.environment_prefix}-IDT"
-    domain_display_non_prod_name = "OCI-ELZ-${local.nonprod_environment.environment_prefix}-IDT"
+    domain_display_prod_name     = "${var.resource_label}-OCI-ELZ-${local.prod_environment.environment_prefix}-IDT"
+    domain_display_non_prod_name = "${var.resource_label}-OCI-ELZ-${local.nonprod_environment.environment_prefix}-IDT"
   }
 
   service_connector_archive_policy = {


### PR DESCRIPTION
Included the user variable resource_label in the local tenancy-level resource names to avoid naming conflicts when there are two or more landing zones in one tenancy
