### PR TITLE
OELZ : Removed Realm OC1 Dependency.

### DIFF
--- a/templates/elz-backup/elz-backup-environment/security-variables.tf
+++ b/templates/elz-backup/elz-backup-environment/security-variables.tf
@@ -31,6 +31,12 @@ variable "security_compartment_id" {
   description = "The OCID of security compartment"
 }
 
+variable "oci_realm_key" {
+  type        = string
+  default     = "1"
+  description = "The OCI region Realm Key"
+}
+
 variable "vault_type" {
   type        = string
   description = "The type of vault to create. "

--- a/templates/elz-backup/elz-backup-environment/security.tf
+++ b/templates/elz-backup/elz-backup-environment/security.tf
@@ -19,6 +19,7 @@ module "security" {
   bastion_client_cidr_block_allow_list = var.bastion_client_cidr_block_allow_list
   bastion_target_subnet_id             = module.network.spoke_web_subnet_ocid
   environment_compartment_id           = var.environment_compartment_id
+  oci_realm_key                        = var.oci_realm_key
 
   providers = {
     oci               = oci

--- a/templates/elz-backup/elz-backup-security/main.tf
+++ b/templates/elz-backup/elz-backup-security/main.tf
@@ -23,7 +23,7 @@ locals {
 
     statements = local.create_key ? [
       "Allow service objectstorage-${var.backup_region} to use keys in compartment id ${var.security_compartment_id}",
-      "Allow service blockstorage,FssOc1Prod, OKE, streaming to use keys in compartment id ${var.security_compartment_id}"
+      "Allow service blockstorage,FssOc${var.oci_realm_key}Prod, OKE, streaming to use keys in compartment id ${var.security_compartment_id}"
     ] : []
   }
 

--- a/templates/elz-backup/elz-backup-security/variables.tf
+++ b/templates/elz-backup/elz-backup-security/variables.tf
@@ -33,6 +33,11 @@ variable "backup_region" {
   description = "Name of the backup region"
 }
 
+variable "oci_realm_key" {
+  type        = string
+  description = "The OCI region Realm Key"
+}
+
 variable "security_compartment_id" {
   type        = string
   description = "The OCID of security compartment"

--- a/templates/elz-environment/main.tf
+++ b/templates/elz-environment/main.tf
@@ -51,6 +51,7 @@ module "identity" {
   home_compartment_id          = var.home_compartment_id
   is_baseline_deploy           = var.is_baseline_deploy
   resource_label               = var.resource_label
+  oci_realm_key                = var.oci_realm_key
 
   providers = {
     oci             = oci
@@ -105,6 +106,7 @@ module "security" {
   enable_replication                   = var.enable_vault_replication
   create_master_encryption_key         = var.create_master_encryption_key
   is_baseline_deploy                   = var.is_baseline_deploy
+  oci_realm_key                        = var.oci_realm_key
 
   providers = {
     oci             = oci

--- a/templates/elz-environment/variables.tf
+++ b/templates/elz-environment/variables.tf
@@ -34,6 +34,10 @@ variable "is_baseline_deploy" {
   type        = bool
   description = "TagNameSpace Optimization: Enable this flag to disable dependent module TagNameSpace Tag Creation."
 }
+variable "oci_realm_key" {
+  type        = string
+  description = "The OCI region Realm Key"
+}
 
 # -----------------------------------------------------------------------------
 # Compartment Variables

--- a/templates/elz-identity/iam.tf
+++ b/templates/elz-identity/iam.tf
@@ -135,7 +135,7 @@ locals {
       "Allow group ${local.identity_domain.domain_display_name}/${local.group_names["security_admin_group_name"]} to inspect keys in compartment ${var.shared_compartment_name}:${var.security_compartment_name}",
       "Allow group ${local.identity_domain.domain_display_name}/${local.group_names["security_admin_group_name"]} to read vss-family in compartment ${var.shared_compartment_name}:${var.security_compartment_name}",
       "Allow group ${local.identity_domain.domain_display_name}/${local.group_names["security_admin_group_name"]} to use bastion in compartment ${var.shared_compartment_name}:${var.security_compartment_name}",
-      "Allow service blockstorage, objectstorage-${var.region}, FssOc1Prod, oke, streaming to use keys in compartment ${var.shared_compartment_name}:${var.security_compartment_name}",
+      "Allow service blockstorage, objectstorage-${var.region}, FssOc${var.oci_realm_key}Prod, oke, streaming to use keys in compartment ${var.shared_compartment_name}:${var.security_compartment_name}",
       ],
       flatten([
         for compartment in var.workload_compartment_names :

--- a/templates/elz-identity/variables.tf
+++ b/templates/elz-identity/variables.tf
@@ -35,6 +35,10 @@ variable "resource_label" {
   description = "Prefix used to avoid naming conflict"
 }
 
+variable "oci_realm_key" {
+  type        = string
+  description = "The OCI region Realm Key"
+}
 # -----------------------------------------------------------------------------
 # Domain Variables
 # -----------------------------------------------------------------------------

--- a/templates/elz-security/main.tf
+++ b/templates/elz-security/main.tf
@@ -43,7 +43,7 @@ locals {
 
     statements = local.create_key ? [
       "Allow service objectstorage-${var.region} to use keys in compartment id ${var.security_compartment_id} where target.key.id = ${module.key[0].key_ocid}",
-      "Allow service blockstorage,FssOc1Prod, OKE, streaming to use keys in compartment id ${var.security_compartment_id} where target.key.id = ${module.key[0].key_ocid}"
+      "Allow service blockstorage,FssOc${var.oci_realm_key}Prod, OKE, streaming to use keys in compartment id ${var.security_compartment_id} where target.key.id = ${module.key[0].key_ocid}"
     ] : []
   }
 

--- a/templates/elz-security/variables.tf
+++ b/templates/elz-security/variables.tf
@@ -37,7 +37,10 @@ variable "region" {
   type        = string
   description = "The OCI region"
 }
-
+variable "oci_realm_key" {
+  type        = string
+  description = "The OCI region Realm Key"
+}
 variable "security_compartment_id" {
   type        = string
   description = "The OCID of security compartment"

--- a/templates/enterprise-landing-zone/environment.tf
+++ b/templates/enterprise-landing-zone/environment.tf
@@ -20,6 +20,7 @@ module "prod_environment" {
   tenancy_ocid   = var.tenancy_ocid
   region         = var.region
   resource_label = var.resource_label
+  oci_realm_key  = var.oci_realm_key
 
   home_compartment_id        = module.home_compartment.compartment_id
   environment_prefix         = local.prod_environment.environment_prefix
@@ -201,6 +202,7 @@ module "nonprod_environment" {
   tenancy_ocid   = var.tenancy_ocid
   region         = var.region
   resource_label = var.resource_label
+  oci_realm_key  = var.oci_realm_key
 
   home_compartment_id        = module.home_compartment.compartment_id
   environment_prefix         = local.nonprod_environment.environment_prefix

--- a/templates/enterprise-landing-zone/logging.tf
+++ b/templates/enterprise-landing-zone/logging.tf
@@ -44,7 +44,7 @@ locals {
 
     statements = [
       "Allow service objectstorage-${var.region} to use keys in compartment id ${module.prod_environment.compartment.security.id}",
-      "Allow service blockstorage,FssOc1Prod, OKE, streaming to use keys in compartment id ${module.prod_environment.compartment.security.id}"
+      "Allow service blockstorage,FssOc${var.oci_realm_key}Prod, OKE, streaming to use keys in compartment id ${module.prod_environment.compartment.security.id}"
     ]
   }
 

--- a/templates/enterprise-landing-zone/variables.tf
+++ b/templates/enterprise-landing-zone/variables.tf
@@ -30,6 +30,12 @@ variable "is_nonprod_env_deploy" {
   default     = true
   description = "Deploy Non-Production Enviornment"
 }
+variable "oci_realm_key" {
+  type        = string
+  default     = "1"
+  description = "The OCI region Realm Key"
+}
+
 
 # -----------------------------------------------------------------------------
 # Compartment Variables


### PR DESCRIPTION
Added a New Variable to remove the OELZv2 OCI Realm Dependency.

New  Variable oci_realm_key with default value to 1 i.e. the OELZ solution will deploy successfully on the OC1.
If the customer wants to deploy the OELZ on a different realm they can change this variable.